### PR TITLE
Add Maven Enforcer Plugin to ensure build with JDK8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CHANGELOG
+
+## [4.0.1] - 2020-03-31
+
+No changes to code, but we are re-publishing the 4.0.0 release compiled with Java 8 to fix [Issue
+#5](https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin/issues/5). We had to use a new version number
+because Maven releases are considered immutable, and we cannot replace the existing 4.0.0 artifact.
+
+## [4.0.0] - 2020-03-17
+
+Initial Release

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# IMPORTANT: Java 8 Support
+
+If you are using Java 8, you need to use at least version 4.0.1 of the plugin. The 4.0.0 version was built with JDK9,
+which includes a breaking API change in ByteBuffer, despite targetting Java 8 source and bytecode.
+
 # What
 
 This package implements an authentication plugin for the open-source Datastax Java Driver for Apache Cassandra. The driver enables you to add authentication information to your API requests using the AWS Signature Version 4 Process (SigV4). Using the plugin, you can provide users and applications short-term credentials to access Amazon Managed Apachce Cassandra Service (MCS) using AWS Identity and Access Management (IAM) users and roles.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.aws.mcs</groupId>
     <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <name>AWS SigV4 Auth Java Driver 4.x Plugin</name>
     <description>A Plugin to allow SigV4 authentication for Java Cassandra drivers with Amazon MCS</description>
     <url>https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin</url>
@@ -152,6 +152,26 @@
                             <goal>update-file-header</goal>
                         </goals>
                         <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[1.8,1.9)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This configures the enforcer plugin as part of the build to ensure
that only Java 8 is used to build the plugin. This ensures that we do
not accidentally compile with Java 9 or later, which has breaking API
changes to the ByteBuffer class.

fixes #5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
