### PR TITLE
Fix SigV4 timestamp formatting to match SigV4 Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [4.0.2] - 2020-03-31
+
+Changed the plugin to use a `DateTimeFormatter` to ensure precisely 3 digits of millisecond precision for the SigV4
+timestamp. A change between JDK8 and JDK11 caused the output of `java.time.Instant.toString()` to change from 3 to 6
+digits, which results in a signature mismatch.
+
 ## [4.0.1] - 2020-03-31
 
 No changes to code, but we are re-publishing the 4.0.0 release compiled with Java 8 to fix [Issue

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.aws.mcs</groupId>
     <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2</version>
     <name>AWS SigV4 Auth Java Driver 4.x Plugin</name>
     <description>A Plugin to allow SigV4 authentication for Java Cassandra drivers with Amazon MCS</description>
     <url>https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin</url>


### PR DESCRIPTION
A change was introduced somewhere between JDK8 and JDK11 that
increased the resolution of the formatted value of java.time.Instant
so that it  went from millisecond to microsecond resolution. Because
the SigV4 spec uses millisecond resolution, the resulting string
caused a signature mismatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
