### PR TITLE
Fix newline handling on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [4.0.3] - 2020-05-15
+
+Updated the plugin to fix newlines used in the SigV4 signature on Windows. This resolves [Issue
+#12](https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin/issues/12).
+
 ## [4.0.2] - 2020-03-31
 
 Changed the plugin to use a `DateTimeFormatter` to ensure precisely 3 digits of millisecond precision for the SigV4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IMPORTANT: Latest Version
 
-The current version is 4.0.2. The 4.0.0 version was built with JDK9, which includes a breaking API change in ByteBuffer, despite targetting Java 8 source and bytecode. The 4.0.1 version has a bug related to `Instant.toString()`, which causes signature mismatch errors on JDK9 and later.
+The current version is 4.0.3. Please see the [changelog](./CHANGELOG.md) for details on version history.
 
 # What
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.aws.mcs</groupId>
     <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
-    <version>4.0.2</version>
+    <version>4.0.3</version>
     <name>AWS SigV4 Auth Java Driver 4.x Plugin</name>
     <description>A Plugin to allow SigV4 authentication for Java Cassandra drivers with Amazon MCS</description>
     <url>https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin</url>

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -275,7 +275,7 @@ public class SigV4AuthProvider implements AuthProvider {
 
         String canonicalRequest = canonicalizeRequest(credentials.getAWSAccessKeyId(), signingScope, requestTimestamp, nonceHash);
 
-        String stringToSign = String.format("%s%n%s%n%s%n%s",
+        String stringToSign = String.format("%s\n%s\n%s\n%s",
                                             SignerConstants.AWS4_SIGNING_ALGORITHM,
                                             timestampFormatter.format(requestTimestamp),
                                             signingScope,
@@ -313,7 +313,7 @@ public class SigV4AuthProvider implements AuthProvider {
 
         String queryString = String.join("&", queryStringHeaders);
 
-        return String.format("PUT%n/authenticate%n%s%nhost:%s%n%nhost%n%s",
+        return String.format("PUT\n/authenticate\n%s\nhost:%s\n\nhost\n%s",
                              queryString, CANONICAL_SERVICE, payloadHash);
     }
 


### PR DESCRIPTION
Fixes #12

*Description of changes:*

Change the newline handling in the SigV4 signature generation to use
newlines explicitly instead of the system-dependent newline character(s).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
