### PR TITLE
Introducing 3.x Driver support (new branch)

### DIFF
--- a/.idea/libraries/Maven__org_ow2_asm_asm_5_0_3.xml
+++ b/.idea/libraries/Maven__org_ow2_asm_asm_5_0_3.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.ow2.asm:asm:5.0.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/ow2/asm/asm/5.0.3/asm-5.0.3-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/ow2/asm/asm/5.0.3/asm-5.0.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## [3.0.3] - 2020-10-18
+
+Added support for 3.x DataStax Driver in the form of additional branch: 3.x-Driver-Compatible.
 
 ## [4.0.3] - 2020-05-15
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,33 @@
-# IMPORTANT: Latest Version
+# Use this branch for 3.x version of the DataStax Cassandra client java driver. 
 
-The current version is 4.0.3. Please see the [changelog](./CHANGELOG.md) for details on version history.
+``` xml
+<dependency>
+    <groupId>software.aws.mcs</groupId>
+    <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin_3</artifactId>
+    <version>3.0.3</version>
+</dependency>
+<dependency>
+    <groupId>com.datastax.cassandra</groupId>
+    <artifactId>cassandra-driver-core</artifactId>
+    <version>3.7.2</version>
+</dependency>
+```
+
+# IMPORTANT: Latest Version
+The current version : 
+- 3.0.3 for DataStax Java Driver 3.x support (see 3.x-Driver-Compatible).
+- 4.0.3 for DataStax Java Driver 4.x Support (see master).
+
+Please see the [changelog](./CHANGELOG.md) for details on version history.
 
 # What
-
-This package implements an authentication plugin for the open-source Datastax Java Driver for Apache Cassandra. The driver enables you to add authentication information to your API requests using the AWS Signature Version 4 Process (SigV4). Using the plugin, you can provide users and applications short-term credentials to access Amazon Keyspaces (for Apache Cassandra) using AWS Identity and Access Management (IAM) users and roles.
+This package implements an authentication plugin for the open-source DataStax Java Driver (3.x) for Apache Cassandra. The driver enables you to add authentication information to your API requests using the AWS Signature Version 4 Process (SigV4). Using the plugin, you can provide users and applications short-term credentials to access Amazon Keyspaces (for Apache Cassandra) using AWS Identity and Access Management (IAM) users and roles.
 
 The plugin depends on the AWS SDK for Java. It uses `AWSCredentialsProvider` to obtain credentials. Because the IAuthenticator interface operates at the level of `InetSocketAddress`, you must specify the service endpoint to use for the connection.
 You can provide the Region in the constructor programmatically, via the `AWS_REGION` environment variable, or via the `aws.region` system property.
 
 The full documentation for the plugin is available at
-https://docs.aws.amazon.com/keyspaces/latest/devguide/programmatic.credentials.html#programmatic.credentials.SigV4_KEYSPACES.
+[AWS Keyspaces SigV4 Documentation](https://docs.aws.amazon.com/keyspaces/latest/devguide/programmatic.credentials.html#programmatic.credentials.SigV4_KEYSPACES).
 
 # Example Usage
 
@@ -18,7 +35,8 @@ For example code, see https://github.com/aws-samples/aws-sigv4-auth-cassandra-ja
 
 # Using the Plugin
 
-The following sections describe how to use the authentication plugin for the open-source DataStax Java Driver for Cassandra to access Amazon Keyspaces.
+The following sections describe how to use the authentication plugin for the open-source DataStax Java Driver 
+for Cassandra to access Amazon Keyspaces.
 
 ## SSL Configuration
 
@@ -60,71 +78,39 @@ Set the Region explicitly in your `advanced.auth-provider.class` configuration (
 
 ## Add the Authentication Plugin to the Application
 
-The authentication plugin supports version 4.x of the DataStax Java Driver for Cassandra. If you’re using Apache Maven, or a build system that can use Maven dependencies, add the following dependencies to your `pom.xml` file.
+The authentication plugin supports version 3.x of the DataStax Java Driver for Cassandra. If you’re using Apache Maven, or a build system that can use Maven dependencies, add the following dependencies to your `pom.xml` file.
 
 ``` xml
 <dependency>
     <groupId>software.aws.mcs</groupId>
     <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
-    <version>4.0.2</version>
+    <version>3.0.3</version>
 </dependency>
 ```
 
 ## How to use the Authentication Plugin
 
-When using the open-source DataStax Java driver, the connection to your Amazon Keyspaces endpoint is represented by the `CqlSession` class. To create the `CqlSession`, you can either configure it programmatically using the `CqlSessionBuilder` class (accessed via `CqlSession.builder()`) or with the configuration file.
+When using the open-source DataStax Java driver, the connection to your Amazon Keyspaces endpoint is represented by the `Session` class. To create the `Session`, you can either configure it programmatically using the `Cluster` class.
 
 ### Programmatically Configure the Driver
 
-When using the DataStax Java driver, you interact with Amazon Keyspaces primarily through the `CQLSession` class. You can create an instance of `CqlSession` using the `CqlSession.builder()` function. `CqlSession.builder()` enables you to specify another authentication provider for the session by using the with `withAuthProvider` function.
+When using the DataStax Java driver, you interact with Amazon Keyspaces primarily through the `Session` class. You can create an instance of `Session` using the `Cluster.builder()` function. `Cluster.builder()` enables you to specify another authentication provider for the session by using the with `withAuthProvider` function.
 
 To use the authentication plugin, you set a Region-specific instance of SigV4AuthProvider as the authentication provider, as in the following example.
 
-1. Call `addContactPoints` on the builder with a collection of `java.net.InetSocketAddress` instances corresponding to the endpoints for your Region. Contact points are the endpoints that the driver will connect to. For a full list of endpoints and Regions in the documentation, see [Service Endpoints for Amazon Keyspaces](https://docs.aws.amazon.com/keyspaces/latest/devguide/programmatic.endpoints.html).
-1. Add an SSL context by calling `withSslContext` on the builder. This uses the trust store defined previously to negotiate SSL on the connection to the endpoints. SSL is required for Amazon Keyspaces. Without this setting, connections will time out and fail.
-1. Set the local data center to the region name, in this example it is `us-east-2`. The local data center is used by the driver for routing of requests, and it is required when the builder is constructed with `addContactPoints`.
+1. Call `addContactPoint` on the builder with a string corresponding to the endpoints for your Region. Contact points are the endpoints that the driver will connect to. For a full list of endpoints and Regions in the documentation, see [Service Endpoints for Amazon Keyspaces](https://docs.aws.amazon.com/keyspaces/latest/devguide/programmatic.endpoints.html).
+1. Add an SSL context by calling `withSsl` on the builder. This uses the trust store defined previously to negotiate SSL on the connection to the endpoints. SSL is required for Amazon Keyspaces. Without this setting, connections will time out and fail.
 1. Set the authentication provider to a new instance of `software.aws.mcs.auth.SigV4AuthProvider`. The `SigV4AuthProvider` is the authentication handler provided by the plugin for performing SigV4 authentication. You can specify the Region for the endpoints that you’re using in the constructor for `SigV4AuthProvider`, as in the following example. Or, you can set the environment variable or system property as shown previously.
 
 The following code example demonstrates the previous steps.
 
 ``` java
-    List<InetSocketAddress> contactPoints =
-      Collections.singletonList(
-       InetSocketAddress.createUnresolved("cassandra.us-east-2.amazonaws.com", 9142));
-
-    try (CqlSession session = CqlSession.builder()
-      .addContactPoints(contactPoints)
-      .withSslContext(SSLContext.getDefault())
-      .withLocalDatacenter("us-east-2")
-      .withAuthProvider(new SigV4AuthProvider("us-east-2"))
-      .build()) {
+    try (Session session = Cluster.builder()
+                .addContactPoint("cassandra.us-east-2.amazonaws.com")
+                .withPort(9142)
+                .withSSL()
+                .withAuthProvider(new SigV4AuthProvider("us-east-2"))
+                .build().connect()) {
       // App code here...
-    }
-```
-
-### Use a Configuration File
-
-To use the configuration file, set the `advanced.auth-provider.class` to `software.aws.mcs.auth.SigV4AuthProvider`. You can also set the region, local data center and enable SSL in the configuration.
-
-1. Set the `advanced.auth-provider.class` to `software.aws.mcs.auth.SigV4AuthProvider`.
-1. Set `basic.load-balancing-policy.local-datacenter` to the region name. In this case, use `us-east-2`.
-
-The following is an example of this.
-
-``` text
-    datastax-java-driver {
-        basic.load-balancing-policy {
-            class = DefaultLoadBalancingPolicy
-            local-datacenter = us-east-2
-        }
-        advanced {
-            auth-provider = {
-                class = software.aws.mcs.auth.SigV4AuthProvider
-                aws-region = us-east-2
-            }
-            ssl-engine-factory {
-                class = DefaultSslEngineFactory
-            }
-        }
     }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.aws.mcs</groupId>
-    <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
+    <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin_3</artifactId>
     <version>4.0.3</version>
-    <name>AWS SigV4 Auth Java Driver 4.x Plugin</name>
-    <description>A Plugin to allow SigV4 authentication for Java Cassandra drivers with Amazon MCS</description>
+    <name>AWS SigV4 Auth Java Driver 3.x Plugin</name>
+    <description>A Plugin to allow SigV4 authentication for Java Cassandra drivers with Amazon Keyspaces</description>
     <url>https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin</url>
     <organization>
         <name>Amazon Web Services</name>
@@ -51,10 +51,11 @@
             <version>1.11.717</version>
         </dependency>
         <dependency>
-            <groupId>com.datastax.oss</groupId>
-            <artifactId>java-driver-core</artifactId>
-            <version>4.4.0</version>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>3.7.2</version>
         </dependency>
+
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
@@ -111,7 +112,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+           <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>1.6</version>

--- a/src/test/java/software/aws/mcs/auth/SigV4AuthProviderTest.java
+++ b/src/test/java/software/aws/mcs/auth/SigV4AuthProviderTest.java
@@ -1,33 +1,28 @@
-package software.aws.mcs.auth;
-
-/*-
- * #%L
- * AWS SigV4 Auth Java Driver 4.x Plugin
- * %%
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.Test;
+package software.aws.mcs.auth;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SigV4AuthProviderTest {
     @Test


### PR DESCRIPTION
Introduces 3.x Driver support by introduction of a separate branch.
This is because many users still use the older version of DataStax Drivers.
Cleaned up version of michaelraney's branch/fix

Updated Readme to reflect correct instructions for 3.x, and updated the
copyright to the latest version.

Co-authored-by: michaelraney <raneymike83@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
