### PR TITLE
default behavior for configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,10 @@
                         <!-- Generally, consumers of the shaded JAR
                              will already have the driver if they want
                              the plugin -->
-                        <excludes>com.datastax.oss</excludes>
+                        <excludes>
+                            <exclude>com.datastax.oss</exclude>
+                            <exclude>com.fasterxml.jackson.core</exclude>
+                        </excludes>
                     </artifactSet>
                 </configuration>
                 <executions>

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -130,8 +130,7 @@ public class SigV4AuthProvider implements AuthProvider {
      * Unused for this plugin.
      */
     public SigV4AuthProvider(DriverContext driverContext) {
-        this(DefaultAWSCredentialsProviderChain.getInstance(),
-                (driverContext.getConfig().getDefaultProfile().getString(REGION_OPTION, null)));
+        this(driverContext.getConfig().getDefaultProfile().getString(REGION_OPTION, null));
     }
 
     /**

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -132,7 +132,8 @@ public class SigV4AuthProvider implements AuthProvider {
      * Unused for this plugin.
      */
     public SigV4AuthProvider(DriverContext driverContext) {
-        this(driverContext.getConfig().getDefaultProfile().getString(REGION_OPTION));
+        this(DefaultAWSCredentialsProviderChain.getInstance(),
+                (driverContext.getConfig().getDefaultProfile().getString(REGION_OPTION, null)));
     }
 
     /**

--- a/src/test/java/software/aws/mcs/auth/TestSigV4.java
+++ b/src/test/java/software/aws/mcs/auth/TestSigV4.java
@@ -60,7 +60,7 @@ public class TestSigV4 {
         }
         if (region == null) {
             throw new IllegalStateException(
-                    "When specifying contact points you must specify a localdc, in this sample we use the AWS_REGION env variable, or aws.region system property"
+                    "When specifying contact points you must specify a localdc. In this sample we use the AWS_REGION env variable, or aws.region system property value as localdc"
             );
         }
 

--- a/src/test/java/software/aws/mcs/auth/TestSigV4.java
+++ b/src/test/java/software/aws/mcs/auth/TestSigV4.java
@@ -69,7 +69,6 @@ public class TestSigV4 {
         // This class is thread-safe, you should create a single instance (per target Cassandra cluster), and share
         // it throughout your application.
         try (CqlSession session = CqlSession.builder()
-
              .addContactPoints(contactPoints)
              .withAuthProvider(new SigV4AuthProvider())
              .withSslContext(SSLContext.getDefault())

--- a/src/test/java/software/aws/mcs/auth/TestSigV4.java
+++ b/src/test/java/software/aws/mcs/auth/TestSigV4.java
@@ -20,11 +20,6 @@ package software.aws.mcs.auth;
  * #L%
  */
 
-import com.amazonaws.SDKGlobalConfiguration;
-import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.cql.*;
-
-import software.aws.mcs.auth.SigV4AuthProvider;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import javax.net.ssl.SSLContext;
@@ -55,28 +50,16 @@ public class TestSigV4 {
 
         System.out.println("Using endpoints: " + contactPoints);
 
-        String region = null;
-        if (System.getProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY) != null) {
-            region = System.getProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY);
-        } else {
-            region = System.getenv(SDKGlobalConfiguration.AWS_REGION_ENV_VAR);
-        }
-        if (region == null) {
-            throw new IllegalStateException(
-                    "When specifying contact points you must specify a localdc. In this sample we use the AWS_REGION env variable, or aws.region system property value as localdc"
-            );
-        }
-
         // The CqlSession object is the main entry point of the driver.
         // It holds the known state of the actual Cassandra cluster (notably the Metadata).
         // This class is thread-safe, you should create a single instance (per target Cassandra cluster), and share
         // it throughout your application.
         try (CqlSession session = CqlSession.builder()
-             .addContactPoints(contactPoints)
-             .withAuthProvider(new SigV4AuthProvider())
-             .withSslContext(SSLContext.getDefault())
-             .withLocalDatacenter(region)
-             .build()) {
+                .addContactPoints(contactPoints)
+                .withAuthProvider(new SigV4AuthProvider())
+                .withSslContext(SSLContext.getDefault())
+                .withLocalDatacenter("us-west-2")
+                .build()) {
 
             // We use execute to send a query to Cassandra. This returns a ResultSet, which is essentially a collection
             // of Row objects.

--- a/src/test/java/software/aws/mcs/auth/TestSigV4.java
+++ b/src/test/java/software/aws/mcs/auth/TestSigV4.java
@@ -60,7 +60,7 @@ public class TestSigV4 {
         }
         if (region == null) {
             throw new IllegalStateException(
-                    "When specifying contact points you must specify a localdc, in this sample we reuse the AWS_REGION env variable, or aws.region system property"
+                    "When specifying contact points you must specify a localdc, in this sample we use the AWS_REGION env variable, or aws.region system property"
             );
         }
 
@@ -73,7 +73,7 @@ public class TestSigV4 {
              .addContactPoints(contactPoints)
              .withAuthProvider(new SigV4AuthProvider())
              .withSslContext(SSLContext.getDefault())
-                .withLocalDatacenter(region)
+             .withLocalDatacenter(region)
              .build()) {
 
             // We use execute to send a query to Cassandra. This returns a ResultSet, which is essentially a collection

--- a/src/test/java/software/aws/mcs/auth/TestSigV4Config.java
+++ b/src/test/java/software/aws/mcs/auth/TestSigV4Config.java
@@ -4,7 +4,7 @@ package software.aws.mcs.auth;
  * #%L
  * AWS SigV4 Auth Java Driver 4.x Plugin
  * %%
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright (C) 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,19 +20,15 @@ package software.aws.mcs.auth;
  * #L%
  */
 
-import com.amazonaws.SDKGlobalConfiguration;
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.ArrayList;
+
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
-
-import javax.net.ssl.SSLContext;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.net.InetSocketAddress;
-import java.net.URL;
-import java.util.ArrayList;
 
 public class TestSigV4Config {
     static String[] DEFAULT_CONTACT_POINTS = {"127.0.0.1:9042"};
@@ -56,18 +52,6 @@ public class TestSigV4Config {
 
         System.out.println("Using endpoints: " + contactPoints);
 
-        String region = null;
-        if (System.getProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY) != null) {
-            region = System.getProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY);
-        } else {
-            region = System.getenv(SDKGlobalConfiguration.AWS_REGION_ENV_VAR);
-        }
-        if (region == null) {
-            throw new IllegalStateException(
-                    "When specifying contact points you must specify a localdc. In this sample we use the AWS_REGION env variable, or aws.region system property value as localdc"
-            );
-        }
-
         //By default the reference.conf is loaded by the driver which contains all defaults.
         //You can override this by providing reference.conf on the classpath
         //to isolate test you can load conf with a custom name
@@ -81,7 +65,7 @@ public class TestSigV4Config {
         try (CqlSession session = CqlSession.builder()
                 .withConfigLoader(DriverConfigLoader.fromFile(file))
                 .addContactPoints(contactPoints)
-                .withLocalDatacenter(region)
+                .withLocalDatacenter("us-west-2")
              .build()) {
 
             // We use execute to send a query to Cassandra. This returns a ResultSet, which is essentially a collection

--- a/src/test/java/software/aws/mcs/auth/TestSigV4Config.java
+++ b/src/test/java/software/aws/mcs/auth/TestSigV4Config.java
@@ -64,7 +64,7 @@ public class TestSigV4Config {
         }
         if (region == null) {
             throw new IllegalStateException(
-                    "A region must be specified by constructor, AWS_REGION env variable, or aws.region system property"
+                    "When specifying contact points you must specify a localdc, in this sample we use the AWS_REGION env variable, or aws.region system property"
             );
         }
 

--- a/src/test/java/software/aws/mcs/auth/TestSigV4Config.java
+++ b/src/test/java/software/aws/mcs/auth/TestSigV4Config.java
@@ -64,7 +64,7 @@ public class TestSigV4Config {
         }
         if (region == null) {
             throw new IllegalStateException(
-                    "When specifying contact points you must specify a localdc, in this sample we use the AWS_REGION env variable, or aws.region system property"
+                    "When specifying contact points you must specify a localdc. In this sample we use the AWS_REGION env variable, or aws.region system property value as localdc"
             );
         }
 

--- a/src/test/resources/keyspaces-reference.conf
+++ b/src/test/resources/keyspaces-reference.conf
@@ -1,0 +1,13 @@
+datastax-java-driver {
+  advanced {
+      reconnect-on-init=true
+
+      auth-provider {
+        class = software.aws.mcs.auth.SigV4AuthProvider
+      }
+      ssl-engine-factory {
+         class = DefaultSslEngineFactory
+         hostname-validation = false
+       }
+   }
+}


### PR DESCRIPTION
When specifying the sigv4 authentication via the configuration file results in exception if the region name is not provided. This is a different default behavior than the programmatic instantiation. The following change will attempt to read the aws region from the environment variables/aws sdk configuration if no region is specified.  

*Description of changes:*
passes null if region is not found in the configuration
new test using configuration 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
