### PR TITLE
Fix region case mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
                     </execution>
                 </executions>
             </plugin>
-           <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>1.6</version>
@@ -136,25 +136,6 @@
                     <nexusUrl>https://aws.oss.sonatype.org</nexusUrl>
                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.0.0</version>
-                <configuration>
-                    <copyrightOwners>Amazon.com, Inc. or its affiliates. All Rights Reserved.</copyrightOwners>
-                    <licenseName>apache_v2</licenseName>
-                    <roots>src</roots>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>first</id>
-                        <goals>
-                            <goal>update-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -111,22 +111,26 @@ public class SigV4AuthProvider implements AuthProvider {
     public SigV4AuthProvider(@NotNull AWSCredentialsProvider credentialsProvider, final String region) {
         this.credentialsProvider = credentialsProvider;
 
+        String rawSigningRegion;
+
         if (region == null) {
             if (System.getProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY) != null) {
-                this.signingRegion = System.getProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY);
+                rawSigningRegion = System.getProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY);
             } else {
-                this.signingRegion = System.getenv(SDKGlobalConfiguration.AWS_REGION_ENV_VAR);
+                rawSigningRegion = System.getenv(SDKGlobalConfiguration.AWS_REGION_ENV_VAR);
             }
         } else {
-            this.signingRegion = region;
+            rawSigningRegion = region;
         }
 
-        if (this.signingRegion == null) {
+        if (rawSigningRegion == null) {
             throw new IllegalStateException(
                 "A region must be specified by constructor, AWS_REGION env variable, or aws.region system property"
             );
         }
 
+        // Ensure that the region is lower case for signing purposes
+        this.signingRegion = rawSigningRegion.toLowerCase();
     }
 
     @Override


### PR DESCRIPTION
*Issue #, if available:*

Bug found during testing, so no issue raised

*Description of changes:*

Ensure that the region passed in is lowercase, since that's what the SigV4 signing mechanism requires. Also clean up POM plugins to remove the license formatter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
