### PR TITLE
Fix region case mismatch for 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,25 +142,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.0.0</version>
-                <configuration>
-                    <copyrightOwners>Amazon.com, Inc. or its affiliates. All Rights Reserved.</copyrightOwners>
-                    <licenseName>apache_v2</licenseName>
-                    <roots>src</roots>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>first</id>
-                        <goals>
-                            <goal>update-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.0.0-M3</version>

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -156,10 +156,9 @@ public class SigV4AuthProvider implements AuthProvider {
         if (region == null) {
             DefaultAwsRegionProviderChain chain = new DefaultAwsRegionProviderChain();
             Region defaultRegion = chain.getRegion();
-            this.signingRegion = defaultRegion.toString();
-
+            this.signingRegion = defaultRegion.toString().toLowerCase();
         } else {
-            this.signingRegion = region;
+            this.signingRegion = region.toLowerCase();
         }
 
         if (this.signingRegion == null) {


### PR DESCRIPTION
Issue #, if available:

Bug found during testing, so no issue raised

Description of changes:

Ensure that the region passed in is lowercase, since that's what the SigV4 signing mechanism requires. Also clean up POM plugins to remove the license formatter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.