### PR TITLE
Bump Jackson versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,24 @@
 # CHANGELOG
 
+## [4.0.7] - 2022-10-05
+
+Updated Jackson version to 2.13.4 to address CVE-2022-42004. This is a transitive dependency of the driver and the SigV4
+plugin does not use Jackson directly.
+
+## [4.0.6] - 2022-04-21
+
+Updated Jackson version to 2.13.2
+
+## [4.0.5] - 2022-02-01
+
+* Fixed a bug with region case sensitivity to match the SigV4 spec
+* Updated the driver dependency to 4.13.0, including overriding transitive Jackson dependencies to ensure currency
+* Removed the Maven license plugin in favor of manual management
+
 ## [4.0.4] - 2021-01-20
 
 Updated to AWS 2 SDK.
-  
+
 
 ## [4.0.3] - 2020-05-15
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IMPORTANT: Latest Version
 
-The current version is 4.0.6. Please see the [changelog](./CHANGELOG.md) for details on version history.
+The current version is 4.0.7. Please see the [changelog](./CHANGELOG.md) for details on version history.
 
 # What
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.aws.mcs</groupId>
     <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.7</version>
     <name>AWS SigV4 Auth Java Driver 4.x Plugin</name>
     <description>A Plugin to allow SigV4 authentication for Java Cassandra drivers with Amazon MCS</description>
     <url>https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin</url>
@@ -42,6 +42,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.13.4</jackson.version>
     </properties>
 
     <dependencies>
@@ -64,17 +65,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- Test Dependencies -->
         <dependency>


### PR DESCRIPTION

*Description of changes:*

Update Jackson version for CVE-2022-42004. Jackson is a transitive dependency brought in from the Cassandra drivers and is not used directly by the SigV4 plugin. Also updated the CHANGELOG, which had missed some entries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
