### PR TITLE
Bump jackson-databind version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [4.0.8] - 2022-12-06
+
+Updated Jackson-databind version to 2.13.4.1.
+
 ## [4.0.7] - 2022-10-05
 
 Updated Jackson version to 2.13.4 to address CVE-2022-42004. This is a transitive dependency of the driver and the SigV4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IMPORTANT: Latest Version
 
-The current version is 4.0.7. Please see the [changelog](./CHANGELOG.md) for details on version history.
+The current version is 4.0.8. Please see the [changelog](./CHANGELOG.md) for details on version history.
 
 # What
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>2.13.4</jackson.version>
+        <jackson-databind.version>2.13.4.1</jackson-databind.version>
     </properties>
 
     <dependencies>
@@ -70,7 +71,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.aws.mcs</groupId>
     <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
     <name>AWS SigV4 Auth Java Driver 4.x Plugin</name>
     <description>A Plugin to allow SigV4 authentication for Java Cassandra drivers with Amazon MCS</description>
     <url>https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin</url>


### PR DESCRIPTION
Dependabot created an [automatic pull request](https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin/pull/30) to update jackson-databind to 2.13.4.1. This pull request fixes jackson-databind and updates the README and changelong.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
