### PR TITLE
Support for assuming role before accessing KeySpaces, helps in cross account access

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To use the configuration file, set the `advanced.auth-provider.class` to `softwa
 1. Set the `advanced.auth-provider.class` to `software.aws.mcs.auth.SigV4AuthProvider`.
 1. Set `basic.load-balancing-policy.local-datacenter` to the region name. In this case, use `us-east-2`.
 
-The following is an example of this.
+The following is an example of this config without explicit role to be assumed. 
 
 ``` text
     datastax-java-driver {
@@ -131,6 +131,27 @@ The following is an example of this.
             auth-provider = {
                 class = software.aws.mcs.auth.SigV4AuthProvider
                 aws-region = us-east-2
+            }
+            ssl-engine-factory {
+                class = DefaultSslEngineFactory
+            }
+        }
+    }
+```
+
+Dollowing is an example of this config with explicit role to be assumed.
+
+``` text
+    datastax-java-driver {
+        basic.load-balancing-policy {
+            class = DefaultLoadBalancingPolicy
+            local-datacenter = us-east-2
+        }
+        advanced {
+            auth-provider = {
+                class = software.aws.mcs.auth.SigV4AuthProvider
+                aws-region = us-east-2
+                aws-role = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
             }
             ssl-engine-factory {
                 class = DefaultSslEngineFactory

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package implements an authentication plugin for the open-source Datastax Ja
 
 The plugin depends on the AWS SDK for Java. It uses `AWSCredentialsProvider` to obtain credentials. Because the IAuthenticator interface operates at the level of `InetSocketAddress`, you must specify the service endpoint to use for the connection.
 You can provide the Region in the constructor programmatically, via the `AWS_REGION` environment variable, or via the `aws.region` system property.
-You can also provide the IAM role, with which you want to connect with KeySpaces, in the constructor programmatically, via advanced.auth-provider.aws-role property in the conf file.
+You can also provide an IAM role to assume for access to KeySpaces, programmatically or via the configuration file.
 
 The full documentation for the plugin is available at
 https://docs.aws.amazon.com/keyspaces/latest/devguide/programmatic.credentials.html#programmatic.credentials.SigV4_KEYSPACES.
@@ -57,22 +57,19 @@ One of the constructors for `software.aws.mcs.auth.SigV4AuthProvider` takes a `S
 
 ### Configuration
 
-Set the Region explicitly in your `advanced.auth-provider.class` configuration (see example below), by specifying the `advanced.auth-provider.aws-region` property.
+Set the Region explicitly in your `advanced.auth-provider` configuration (see example below), by specifying the `advanced.auth-provider.aws-region` property.
 
 ## Assume IAM Role Configuration
 
-You must configure the AWS Region that the plugin will use when authenticating using mechanism mentioned above. 
-You can also specify IAM Role (including cross-account IAM role) configuraiton using one of the 2 methods: 
-* Constructor
-* Configuration
+You can specify an IAM role to assume for access to KeySpaces using either the constructor or the driver configuration file
 
 ### Constructor
 
-One of the constructors for `software.aws.mcs.auth.SigV4AuthProvider` takes two String , first represening the region and second one representing IAM role ARN. 
+One of the constructors for `software.aws.mcs.auth.SigV4AuthProvider` takes two Strings , the first representing the region and the second representing the ARN of the IAM role to assume. 
 
 ### Configuration
 
-Set the IAM Role explicitly in your `advanced.auth-provider.class` configuration (see example below), by specifying the `advanced.auth-provider.aws-role` property.
+Set the IAM Role explicitly in your `advanced.auth-provider` configuration (see example below), by specifying the `advanced.auth-provider.aws-role` property.
 
 ## Add the Authentication Plugin to the Application
 
@@ -155,7 +152,7 @@ The following is an example of this config without explicit role to be assumed.
     }
 ```
 
-Dollowing is an example of this config with explicit role to be assumed.
+The following is an example of this config with an explicit role to be assumed.
 
 ``` text
     datastax-java-driver {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This package implements an authentication plugin for the open-source Datastax Ja
 
 The plugin depends on the AWS SDK for Java. It uses `AWSCredentialsProvider` to obtain credentials. Because the IAuthenticator interface operates at the level of `InetSocketAddress`, you must specify the service endpoint to use for the connection.
 You can provide the Region in the constructor programmatically, via the `AWS_REGION` environment variable, or via the `aws.region` system property.
+You can also provide the IAM role, with which you want to connect with KeySpaces, in the constructor programmatically, via advanced.auth-provider.aws-role property in the conf file.
 
 The full documentation for the plugin is available at
 https://docs.aws.amazon.com/keyspaces/latest/devguide/programmatic.credentials.html#programmatic.credentials.SigV4_KEYSPACES.
@@ -35,14 +36,14 @@ You can specify the Region using one of the following four methods:
 * Constructor
 * Configuration
 
-## Environment Variable
+### Environment Variable
 
 You can use the `AWS_REGION` environment variable to match the endpoint that you are communicating with by setting it as part of your application start-up, as follows.
 
 ``` shell
 $ export AWS_Region=us-east-1
 ```
-## System Property
+### System Property
 
 You can use the `aws.region` Java system property by specifying it on the command line, as follows.
 
@@ -50,13 +51,28 @@ You can use the `aws.region` Java system property by specifying it on the comman
 $ java -Daws.region=us=east-1 ...
 ```
 
-## Constructor
+### Constructor
 
 One of the constructors for `software.aws.mcs.auth.SigV4AuthProvider` takes a `String` representing the Region that will be used for that instance.
 
-## Configuration
+### Configuration
 
 Set the Region explicitly in your `advanced.auth-provider.class` configuration (see example below), by specifying the `advanced.auth-provider.aws-region` property.
+
+## Assume IAM Role Configuration
+
+You must configure the AWS Region that the plugin will use when authenticating using mechanism mentioned above. 
+You can also specify IAM Role (including cross-account IAM role) configuraiton using one of the 2 methods: 
+* Constructor
+* Configuration
+
+### Constructor
+
+One of the constructors for `software.aws.mcs.auth.SigV4AuthProvider` takes two String , first represening the region and second one representing IAM role ARN. 
+
+### Configuration
+
+Set the IAM Role explicitly in your `advanced.auth-provider.class` configuration (see example below), by specifying the `advanced.auth-provider.aws-role` property.
 
 ## Add the Authentication Plugin to the Application
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ One of the constructors for `software.aws.mcs.auth.SigV4AuthProvider` takes two 
 
 ### Configuration
 
-Set the IAM Role explicitly in your `advanced.auth-provider` configuration (see example below), by specifying the `advanced.auth-provider.aws-role` property.
+Set the IAM Role explicitly in your `advanced.auth-provider` configuration (see example below), by specifying the `advanced.auth-provider.aws-role-arn` property.
 
 ## Add the Authentication Plugin to the Application
 
@@ -164,7 +164,7 @@ The following is an example of this config with an explicit role to be assumed.
             auth-provider = {
                 class = software.aws.mcs.auth.SigV4AuthProvider
                 aws-region = us-east-2
-                aws-role = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+                aws-role-arn = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
             }
             ssl-engine-factory {
                 class = DefaultSslEngineFactory

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>2.13.4</jackson.version>
         <jackson-databind.version>2.13.4.2</jackson-databind.version>
+        <aws-sdk-version>2.15.66</aws-sdk-version>
     </properties>
 
     <dependencies>
@@ -88,7 +89,13 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
-            <version>2.15.66</version>
+            <version>${aws-sdk-version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sts -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${aws-sdk-version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.aws.mcs</groupId>
     <artifactId>aws-sigv4-auth-cassandra-java-driver-plugin</artifactId>
-    <version>4.0.9</version>
+    <version>4.0.10</version>
     <name>AWS SigV4 Auth Java Driver 4.x Plugin</name>
     <description>A Plugin to allow SigV4 authentication for Java Cassandra drivers with Amazon MCS</description>
     <url>https://github.com/aws/aws-sigv4-auth-cassandra-java-driver-plugin</url>

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -106,7 +106,7 @@ public class SigV4AuthProvider implements AuthProvider {
 
     private final static DriverOption REGION_OPTION = () -> "advanced.auth-provider.aws-region";
 
-    private final static DriverOption ROLE_OPTION = () -> "advanced.auth-provider.aws-role";
+    private final static DriverOption ROLE_OPTION = () -> "advanced.auth-provider.aws-role-arn";
 
     /**
      * This constructor is provided so that the driver can create

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -133,7 +133,7 @@ public class SigV4AuthProvider implements AuthProvider {
      */
     public SigV4AuthProvider(DriverContext driverContext) {
         this(driverContext.getConfig().getDefaultProfile().getString(REGION_OPTION, getDefaultRegion()),
-                driverContext.getConfig().getDefaultProfile().getString(ROLE_OPTION, null));
+             driverContext.getConfig().getDefaultProfile().getString(ROLE_OPTION, null));
     }
 
     /**
@@ -393,14 +393,10 @@ public class SigV4AuthProvider implements AuthProvider {
      * @param stsRegion The region of the STS endpoint
      * @return The STS role credential provider
      */
-    private static StsAssumeRoleCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
-                                                                     String stsRegion) {
+    private static StsAssumeRoleCredentialsProvider createSTSRoleCredentialProvider(@NotNull String roleArn,
+                                                                            @NotNull String stsRegion) {
         //Get role name from ARN
-        String[] arnParts = roleArn.split("/");
-        if(arnParts.length < 2){
-            throw new IllegalArgumentException("Invalid role ARN");
-        }
-        String roleName = arnParts[arnParts.length - 1];
+        String roleName = getRoleNameFromArn(roleArn);
         final String sessionName="keyspaces-session-"+roleName+System.currentTimeMillis();
         StsClient stsClient = StsClient.builder()
                 .region(Region.of(stsRegion))
@@ -413,6 +409,20 @@ public class SigV4AuthProvider implements AuthProvider {
                 .stsClient(stsClient)
                 .refreshRequest(assumeRoleRequest)
                 .build();
+    }
+
+    /**
+     * Extracts the role name from the ARN.
+     * @param roleArn The ARN of the role to assume
+     * @return
+     */
+    static String getRoleNameFromArn(@NotNull String roleArn) {
+        String[] arnParts = roleArn.split("/");
+        if(arnParts.length < 2){
+            throw new IllegalArgumentException("Invalid role ARN");
+        }
+        String roleName = arnParts[arnParts.length - 1];
+        return roleName;
     }
 
     /**

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -105,11 +105,7 @@ public class SigV4AuthProvider implements AuthProvider {
         this(create(), null);
     }
 
-    private final static DriverOption REGION_OPTION = new DriverOption() {
-            public String getPath() {
-                return "advanced.auth-provider.aws-region";
-            }
-        };
+    private final static DriverOption REGION_OPTION = () -> "advanced.auth-provider.aws-region";
 
     private final static DriverOption ROLE_OPTION = () -> "advanced.auth-provider.aws-role";
 
@@ -397,13 +393,12 @@ public class SigV4AuthProvider implements AuthProvider {
     /**
      * Creates a STS role credential provider
      * @param roleArn The ARN of the role to assume
-     * @param sessionName The name of the session
      * @param stsRegion The region of the STS endpoint
      * @return The STS role credential provider
      */
     private static StsAssumeRoleCredentialsProvider createSTSRoleCredentialProvider(String roleArn,
                                                                      String stsRegion) {
-        final String roleName= StringUtils.substringAfterLast(roleArn,":");
+        final String roleName= StringUtils.substringAfterLast(roleArn,"/");
         final String sessionName="keyspaces-session-"+roleName+System.currentTimeMillis();
         StsClient stsClient = StsClient.builder()
                 .region(Region.of(stsRegion))
@@ -420,7 +415,7 @@ public class SigV4AuthProvider implements AuthProvider {
 
     /**
      * Gets the default region for SigV4 if region is not provided.
-     * @return
+     * @return Default region
      */
     private static String getDefaultRegion() {
         DefaultAwsRegionProviderChain chain = new DefaultAwsRegionProviderChain();

--- a/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
+++ b/src/main/java/software/aws/mcs/auth/SigV4AuthProvider.java
@@ -395,9 +395,7 @@ public class SigV4AuthProvider implements AuthProvider {
      */
     private static StsAssumeRoleCredentialsProvider createSTSRoleCredentialProvider(@NotNull String roleArn,
                                                                             @NotNull String stsRegion) {
-        //Get role name from ARN
-        String roleName = getRoleNameFromArn(roleArn);
-        final String sessionName="keyspaces-session-"+roleName+System.currentTimeMillis();
+        final String sessionName="keyspaces-session-"+System.currentTimeMillis();
         StsClient stsClient = StsClient.builder()
                 .region(Region.of(stsRegion))
                 .build();
@@ -409,20 +407,6 @@ public class SigV4AuthProvider implements AuthProvider {
                 .stsClient(stsClient)
                 .refreshRequest(assumeRoleRequest)
                 .build();
-    }
-
-    /**
-     * Extracts the role name from the ARN.
-     * @param roleArn The ARN of the role to assume
-     * @return
-     */
-    static String getRoleNameFromArn(@NotNull String roleArn) {
-        String[] arnParts = roleArn.split("/");
-        if(arnParts.length < 2){
-            throw new IllegalArgumentException("Invalid role ARN");
-        }
-        String roleName = arnParts[arnParts.length - 1];
-        return roleName;
     }
 
     /**

--- a/src/test/java/software/aws/mcs/auth/SigV4AuthProviderTest.java
+++ b/src/test/java/software/aws/mcs/auth/SigV4AuthProviderTest.java
@@ -87,4 +87,21 @@ public class SigV4AuthProviderTest {
         assertEquals(-1, SigV4AuthProvider.indexOf(target, pattern));
     }
 
+
+    @Test
+    public void testGetRoleNameFromArn() {
+        String arn = "arn:aws:iam::ACCOUNT_ID:role/keyspaces-act2-role";
+        assertEquals("keyspaces-act2-role", SigV4AuthProvider.getRoleNameFromArn(arn));
+    }
+
+    @Test
+    public void testGetRoleNameFromArnFailure() {
+        assertThrows(IllegalArgumentException.class, () -> SigV4AuthProvider.getRoleNameFromArn(""));
+        assertThrows(IllegalArgumentException.class, () -> SigV4AuthProvider.getRoleNameFromArn("roleName"));
+        assertThrows(IllegalArgumentException.class, () -> SigV4AuthProvider.getRoleNameFromArn("illegalerolearn:rolename"));
+    }
+
+
+
+
 }

--- a/src/test/java/software/aws/mcs/auth/SigV4AuthProviderTest.java
+++ b/src/test/java/software/aws/mcs/auth/SigV4AuthProviderTest.java
@@ -87,21 +87,4 @@ public class SigV4AuthProviderTest {
         assertEquals(-1, SigV4AuthProvider.indexOf(target, pattern));
     }
 
-
-    @Test
-    public void testGetRoleNameFromArn() {
-        String arn = "arn:aws:iam::ACCOUNT_ID:role/keyspaces-act2-role";
-        assertEquals("keyspaces-act2-role", SigV4AuthProvider.getRoleNameFromArn(arn));
-    }
-
-    @Test
-    public void testGetRoleNameFromArnFailure() {
-        assertThrows(IllegalArgumentException.class, () -> SigV4AuthProvider.getRoleNameFromArn(""));
-        assertThrows(IllegalArgumentException.class, () -> SigV4AuthProvider.getRoleNameFromArn("roleName"));
-        assertThrows(IllegalArgumentException.class, () -> SigV4AuthProvider.getRoleNameFromArn("illegalerolearn:rolename"));
-    }
-
-
-
-
 }

--- a/src/test/java/software/aws/mcs/auth/TestSigV4Config.java
+++ b/src/test/java/software/aws/mcs/auth/TestSigV4Config.java
@@ -55,7 +55,7 @@ public class TestSigV4Config {
         //By default the reference.conf is loaded by the driver which contains all defaults.
         //You can override this by providing reference.conf on the classpath
         //to isolate test you can load conf with a custom name
-        URL url = TestSigV4Config.class.getClassLoader().getResource("keyspaces-reference.conf");
+        URL url = TestSigV4Config.class.getClassLoader().getResource("keyspaces-reference-norole.conf");
 
         File file = new File(url.toURI());
         // The CqlSession object is the main entry point of the driver.
@@ -64,18 +64,16 @@ public class TestSigV4Config {
         // it throughout your application.
         try (CqlSession session = CqlSession.builder()
                 .withConfigLoader(DriverConfigLoader.fromFile(file))
-                .addContactPoints(contactPoints)
-                .withLocalDatacenter("us-west-2")
              .build()) {
 
             // We use execute to send a query to Cassandra. This returns a ResultSet, which is essentially a collection
             // of Row objects.
-            ResultSet rs = session.execute("select release_version from system.local");
+            ResultSet rs = session.execute("select * from testkeyspace.testconf");
             //  Extract the first row (which is the only one in this case).
             Row row = rs.one();
 
             // Extract the value of the first (and only) column from the row.
-            String releaseVersion = row.getString("release_version");
+            String releaseVersion = row.getString("category");
             System.out.printf("Cassandra version is: %s%n", releaseVersion);
         }
     }

--- a/src/test/resources/ddl.cql
+++ b/src/test/resources/ddl.cql
@@ -1,0 +1,18 @@
+CREATE KEYSPACE "testkeyspace" WITH REPLICATION = {'class': 'SingleRegionStrategy'};
+
+CREATE TABLE "testkeyspace"."testconf"(
+  "id" ascii,
+  "category" ascii,
+  PRIMARY KEY("id")
+)
+WITH CUSTOM_PROPERTIES = {
+  'capacity_mode':{
+  'throughput_mode':'PAY_PER_REQUEST'
+  },
+  'point_in_time_recovery':{
+  'status':'enabled'
+  },
+  'encryption_specification':{
+  'encryption_type':'AWS_OWNED_KMS_KEY'
+  }
+} ;

--- a/src/test/resources/dml.cql
+++ b/src/test/resources/dml.cql
@@ -1,0 +1,1 @@
+INSERT into testkeyspace.testconf(id,category) values('first','first Category');

--- a/src/test/resources/keyspaces-reference-norole.conf
+++ b/src/test/resources/keyspaces-reference-norole.conf
@@ -1,0 +1,24 @@
+datastax-java-driver {
+        basic.contact-points = ["cassandra.ap-south-1.amazonaws.com:9142"]
+        basic.load-balancing-policy {
+            class = DefaultLoadBalancingPolicy
+            local-datacenter = ap-south-1
+            slow-replica-avoidance = false
+        }
+        basic.request {
+              consistency = LOCAL_QUORUM
+        }
+        advanced {
+                auth-provider = {
+                   class = software.aws.mcs.auth.SigV4AuthProvider
+                   aws-region = ap-south-1
+                 }
+            ssl-engine-factory {
+                class = DefaultSslEngineFactory
+                truststore-path = "<path>/cassandra_truststore.jks"
+                truststore-password = "<password>"
+                hostname-validation=false
+            }
+        }
+        advanced.connection.pool.local.size = 3
+}

--- a/src/test/resources/keyspaces-reference-withrole.conf
+++ b/src/test/resources/keyspaces-reference-withrole.conf
@@ -12,7 +12,7 @@ datastax-java-driver {
                 auth-provider = {
                    class = software.aws.mcs.auth.SigV4AuthProvider
                    aws-region = ap-south-1
-                   aws-role = "arn:aws:iam::ACCOUNT_ID:role/keyspaces-act2-role"
+                   aws-role-arn = "arn:aws:iam::ACCOUNT_ID:role/keyspaces-act2-role"
                  }
             ssl-engine-factory {
                 class = DefaultSslEngineFactory

--- a/src/test/resources/keyspaces-reference-withrole.conf
+++ b/src/test/resources/keyspaces-reference-withrole.conf
@@ -1,0 +1,25 @@
+datastax-java-driver {
+        basic.contact-points = ["cassandra.ap-south-1.amazonaws.com:9142"]
+        basic.load-balancing-policy {
+            class = DefaultLoadBalancingPolicy
+            local-datacenter = ap-south-1
+            slow-replica-avoidance = false
+        }
+        basic.request {
+              consistency = LOCAL_QUORUM
+        }
+        advanced {
+                auth-provider = {
+                   class = software.aws.mcs.auth.SigV4AuthProvider
+                   aws-region = ap-south-1
+                   aws-role = "arn:aws:iam::ACCOUNT_ID:role/keyspaces-act2-role"
+                 }
+            ssl-engine-factory {
+                class = DefaultSslEngineFactory
+                truststore-path = "<path>/cassandra_truststore.jks"
+                truststore-password = "<password>"
+                hostname-validation=false
+            }
+        }
+        advanced.connection.pool.local.size = 3
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Support for providing IAM Role ARN is added. With this a cross account access from Spark to KeySpaces is made possible. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
